### PR TITLE
Feature/cc 946

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.3
 MAINTAINER Daniel McCoy <danielmccoy@gmail.com>
 
 RUN apk --update add \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.3
+FROM alpine:3.4
 MAINTAINER Daniel McCoy <danielmccoy@gmail.com>
 
 RUN apk --update add \
@@ -17,9 +17,14 @@ RUN apk --update add \
   php-xml \
   php-gd \
   curl \
+  py-pip \
   php-curl \
   php-zip \
   supervisor
+
+# Configure supervisor
+RUN pip install --upgrade pip && \
+    pip install supervisor-stdout
 
 RUN mkdir -p /etc/nginx
 RUN mkdir -p /run/nginx

--- a/nginx-supervisor.ini
+++ b/nginx-supervisor.ini
@@ -5,12 +5,19 @@ nodaemon=true
 command = /usr/sbin/nginx
 user = root
 autostart = true
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
+autorestart=true
+stdout_events_enabled=true
+stderr_events_enabled=true
 
 [program:php-fpm]
 command = /usr/bin/php-fpm -F
 user = root
 autostart = true
-stdout_logfile=/dev/stdout               
-stdout_logfile_maxbytes=0
+stdout_events_enabled=true
+stderr_events_enabled=true
+
+[eventlistener:stdout]
+command = supervisor_stdout
+buffer_size = 100
+events = PROCESS_LOG
+result_handler = supervisor_stdout:event_handler

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,8 +1,8 @@
 user root;
 
-worker_processes 2;
+worker_processes 5;
 
-error_log  /var/log/nginx/error.log warn;
+error_log  /dev/stderr debug;
 
 events {
   worker_connections 1024;
@@ -16,7 +16,7 @@ http {
                     '$status $body_bytes_sent "$http_referer" '
                     '"$http_user_agent" "$http_x_forwarded_for"';
 
-  access_log  /var/log/nginx/access.log  main;
+  access_log  /dev/stdout  main;
 
   sendfile on;
 

--- a/php-fpm.conf
+++ b/php-fpm.conf
@@ -29,7 +29,7 @@
 ; in a local file.
 ; Note: the default prefix is /var
 ; Default Value: log/php-fpm.log
-error_log = /var/log/php-fpm.log
+error_log = /proc/self/fd/2
 
 ; syslog_facility is used to specify what type of program is logging the
 ; message. This lets syslogd specify that messages from different facilities
@@ -378,7 +378,7 @@ pm.max_spare_servers = 3
 
 ; The access log file
 ; Default: not set
-;access.log = log/$pool.access.log
+access.log = /proc/self/fd/2
 
 ; The access log format.
 ; The following syntax is allowed

--- a/php-fpm.conf
+++ b/php-fpm.conf
@@ -29,7 +29,7 @@
 ; in a local file.
 ; Note: the default prefix is /var
 ; Default Value: log/php-fpm.log
-error_log = /proc/self/fd/2
+error_log = /dev/stderr
 
 ; syslog_facility is used to specify what type of program is logging the
 ; message. This lets syslogd specify that messages from different facilities
@@ -369,7 +369,7 @@ pm.max_spare_servers = 3
 ;       anything, but it may not be a good idea to use the .php extension or it
 ;       may conflict with a real PHP file.
 ; Default Value: not set
-;ping.path = /ping
+ping.path = /ping
 
 ; This directive may be used to customize the response of a ping request. The
 ; response is formatted as text/plain with a 200 response code.
@@ -378,7 +378,7 @@ pm.max_spare_servers = 3
 
 ; The access log file
 ; Default: not set
-access.log = /proc/self/fd/2
+access.log = /dev/stderr
 
 ; The access log format.
 ; The following syntax is allowed


### PR DESCRIPTION
This makes both supervisord and php-fpm (the stream used when Laravel's APP_LOG = errorlog) logging available through docker logs.